### PR TITLE
Update assets/snippets/eform/eform.inc.php

### DIFF
--- a/assets/snippets/eform/eform.inc.php
+++ b/assets/snippets/eform/eform.inc.php
@@ -319,7 +319,7 @@ $tpl = eFormParseTemplate($tpl,$isDebug);
 					switch ($datatype)  {
 
 						case "integer":
-							$value = number_format($value);
+							$value = empty($value)?0:number_format($value);
 							break;
 						case "float":
 							$localeInfo = localeconv();


### PR DESCRIPTION
FIX error number_format() expects parameter 1 to be double, string given
