### PR TITLE
Set parseChunk() default placeholder markers to "[+" and "+] "

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -2296,7 +2296,7 @@ class DocumentParser {
         return $this->getChunk($chunkName);
     }
 
-    function parseChunk($chunkName, $chunkArr, $prefix= "{", $suffix= "}") {
+    function parseChunk($chunkName, $chunkArr, $prefix= "[+", $suffix= "+]") {
         if (!is_array($chunkArr)) {
             return false;
         }


### PR DESCRIPTION
to match normal practice, and save having to write them in every time you use parseChunk(). Existing defaults "{" and "]" seem to be a leftover from Etomite.
