### PR TITLE
Only log error if database selectable

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3587,7 +3587,7 @@ class DocumentParser {
         ob_end_flush();
 
         // Log error if a connection to the db exists
-        if ($this->db->conn) {
+        if ($this->db->dbase) {
              $this->logEvent(0, 3, $parsedMessageString, $source= 'Parser');
         }
 


### PR DESCRIPTION
If you can log in to the DB server (db->conn is a valid resource), but not select the Clipper database named in config.inc.php (so db->dbase is not set), there's no point trying to log errors in an unavailable database - you just get a lot of failure messages with an ever-increasing backslash frenzy.
