### PR TITLE
Bugfix: TV Date Formatter widget

### DIFF
--- a/manager/includes/tmplvars.format.inc.php
+++ b/manager/includes/tmplvars.format.inc.php
@@ -75,6 +75,9 @@ function getTVDisplayFormat($name,$value,$format,$paramstring="",$tvtype="",$doc
 
         case "date":
             if ($value !='' || $params['default']=='Yes') {
+                if (empty($value)) {
+                    $value = 'now';
+                }
                 $timestamp = getUnixtimeFromDateString($value);
                 $p = $params['format'] ? $params['format']:"%A %d, %B %Y";
                 $o = strftime($p,$timestamp);


### PR DESCRIPTION
To show today's date as default when value blank and "default to today" set to Yes.
