### PR TITLE
Remove surplus space preceding webgroup names

### DIFF
--- a/manager/processors/web_access_groups.processor.php
+++ b/manager/processors/web_access_groups.processor.php
@@ -24,8 +24,8 @@ switch ($operation) {
 			echo "no group name specified";
 			exit;
 		} else {
-			$sql = "INSERT IGNORE INTO " . $tbl_webgroup_names . " (name) 
-			VALUES(' " . $modx->db->escape($newgroup). "')"; // Temporary solution pending DBAPI::replace
+			$sql = "INSERT IGNORE INTO " . $tbl_webgroup_names . " (name)
+			VALUES('" . $modx->db->escape($newgroup). "')"; // Temporary solution pending DBAPI::replace
 			$modx->db->query($sql);
 			
 			if(!$modx->db->getAffectedRows()) {


### PR DESCRIPTION
Discovered while testing MemberCheck snippet that webgroup names in table have extra space in front of them.
