### PR TITLE
Display HTML characters in password confirmation message

### DIFF
--- a/manager/processors/save_user.processor.php
+++ b/manager/processors/save_user.processor.php
@@ -239,7 +239,7 @@ switch ($_POST['mode']) {
 			<div class="sectionBody">
 			<div id="disp">
 			<p>
-			<?php echo sprintf($_lang["password_msg"], $newusername, $newpassword); ?>
+			<?php echo sprintf($_lang["password_msg"], $newusername, htmlspecialchars($newpassword)); ?>
 			</p>
 			</div>
 			</div>
@@ -417,7 +417,7 @@ switch ($_POST['mode']) {
 			<div class="sectionBody">
 			<div id="disp">
 			<p>
-			<?php echo sprintf($_lang["password_msg"], $newusername, $newpassword).(($id == $modx->getLoginUserID()) ? ' '.$_lang['user_changeddata'] : ''); ?>
+			<?php echo sprintf($_lang["password_msg"], $newusername, htmlspecialchars($newpassword)).(($id == $modx->getLoginUserID()) ? ' '.$_lang['user_changeddata'] : ''); ?>
 			</p>
 			</div>
 			</div>

--- a/manager/processors/save_web_user.processor.php
+++ b/manager/processors/save_web_user.processor.php
@@ -196,7 +196,7 @@ switch ($_POST['mode']) {
 			<div class="sectionBody">
 			<div id="disp">
 			<p>
-			<?php echo sprintf($_lang["password_msg"], $newusername, $newpassword); ?>
+			<?php echo sprintf($_lang["password_msg"], $newusername, htmlspecialchars($newpassword)); ?>
 			</p>
 			</div>
 			</div>
@@ -363,7 +363,7 @@ switch ($_POST['mode']) {
 			<div class="sectionHeader"><?php echo $_lang['web_user_title']; ?></div>
 			<div class="sectionBody">
 			<div id="disp">
-				<p><?php echo sprintf($_lang["password_msg"], $newusername, $newpassword); ?></p>
+				<p><?php echo sprintf($_lang["password_msg"], $newusername, htmlspecialchars($newpassword)); ?></p>
 			</div>
 			</div>
 		<?php


### PR DESCRIPTION
HTML special characters are allowed in passwords, but need to be entities to show up properly after user is saved
