### PR TITLE
Update clippercms.com and forums URLs in version.inc and help lang files

### DIFF
--- a/manager/includes/lang/bulgarian.inc.php
+++ b/manager/includes/lang/bulgarian.inc.php
@@ -6,7 +6,7 @@
  */
 $modx_lang_attribute = 'bg'; // Manager HTML and XML Language Attribute
 
-$_lang["about_msg"] = CMS_NAME.' is a <a href="http://clippercms.com" target="_blank">PHP Application Framework and Content Management System</a> licensed under the <a href="../assets/docs/license.txt">GNU GPL</a>.';
+$_lang["about_msg"] = CMS_NAME.' is a <a href="http://'.CMS_DOMAIN.'" target="_blank">PHP Application Framework and Content Management System</a> licensed under the <a href="../assets/docs/license.txt">GNU GPL</a>.';
 $_lang["about_title"] = 'За Системата '.CMS_NAME;
 $_lang["access_permission_denied"] = 'Нямате Права за Достъп за този Документ.';
 $_lang["access_permission_parent_denied"] = 'Нямате Права да създавате Документ тук!';
@@ -297,7 +297,7 @@ $_lang["go"] = 'Отиди';
 $_lang["group_access_permissions"] = 'Права за достъп на Група Потребители';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Помощ';
-$_lang["help_msg"] = '<p>Можете да получите безплатна помощ на <a href="http://clippercms.com/forums" target="_blank">адреса на Форума на '.CMS_NAME.'</a>. Също така можете да посетите и <a href="http://clippercms.com/documentation" target="_blank">'.CMS_NAME.' Документация и Ръководства</a> , където са засегнати почти всички аспекти на '.CMS_NAME.'.</p><p>Екипът планира да предложи и платена помощ като услуга също. Моля да се информирате за платената помощ на адрес <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry"></a>.';
+$_lang["help_msg"] = '<p>Можете да получите безплатна помощ на <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">адреса на Форума на '.CMS_NAME.'</a>. Също така можете да посетите и <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.' Документация и Ръководства</a> , където са засегнати почти всички аспекти на '.CMS_NAME.'.</p><p>Екипът планира да предложи и платена помощ като услуга също. Моля да се информирате за платената помощ на адрес <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry"></a>.';
 $_lang["help_title"] = 'Помощ';
 $_lang["hide_tree"] = 'Скриване на дървото';
 $_lang["home"] = 'Начало';

--- a/manager/includes/lang/czech.inc.php
+++ b/manager/includes/lang/czech.inc.php
@@ -339,7 +339,7 @@ $_lang["go"] = 'Hledej';
 $_lang["group_access_permissions"] = 'Přístupová práva skupiny uživatelů';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Pomoc';
-$_lang["help_msg"] = 'Jestliže potřebujete pomoc při používaní systému '.CMS_NAME.', uděláte nejlépe, když navštívíte <a href="http://www.modxcms.cz/" target="_blank">české '.CMS_NAME.' fórum</a>. Najdete tam: návody, dokumentaci používání a nastavení '.CMS_NAME.'. Jestliže pošlete svoji otázku na fórum, budeme se snažit odpovědět, co nejdříve.';
+$_lang["help_msg"] = 'Jestliže potřebujete pomoc při používaní systému '.CMS_NAME.', uděláte nejlépe, když navštívíte <a href="http://'.CMS_DOMAIN.'/forum/" target="_blank">'.CMS_NAME.' fórum</a>. Najdete tam: návody, dokumentaci používání a nastavení '.CMS_NAME.'. Jestliže pošlete svoji otázku na fórum, budeme se snažit odpovědět, co nejdříve.';
 $_lang["help_title"] = 'Pomoc';
 $_lang["hide_tree"] = 'Skrýt';
 $_lang["home"] = 'Domů';

--- a/manager/includes/lang/danish.inc.php
+++ b/manager/includes/lang/danish.inc.php
@@ -339,7 +339,7 @@ $_lang["go"] = 'Gennemfør';
 $_lang["group_access_permissions"] = 'Bruger gruppe adgang';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Hjælp';
-$_lang["help_msg"] = '<p>Du kan få fri og frivillig support <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">hvis du besøger '.CMS_NAME.'\'s Fora</a>. Der er også en større samling af <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">dokumentation og guider til '.CMS_NAME.'</a> som beskriver stort set alle facetter af '.CMS_NAME.'.</p><p>Desuden planlægger vi at tilbyde kommerciel service og support til '.CMS_NAME.'. Kontakt os på <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">e-mail, hvis dette har din interesse (Skriv venligst på engelsk)</a>.</p>';
+$_lang["help_msg"] = '<p>Du kan få fri og frivillig support <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">hvis du besøger '.CMS_NAME.'\'s Fora</a>. Der er også en større samling af <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">dokumentation og guider til '.CMS_NAME.'</a> som beskriver stort set alle facetter af '.CMS_NAME.'.</p><p>Desuden planlægger vi at tilbyde kommerciel service og support til '.CMS_NAME.'. Kontakt os på <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">e-mail, hvis dette har din interesse (Skriv venligst på engelsk)</a>.</p>';
 $_lang["help_title"] = 'Hjælp';
 $_lang["hide_tree"] = 'Skjul website træet';
 $_lang["home"] = 'Startside';

--- a/manager/includes/lang/english-british.inc.php
+++ b/manager/includes/lang/english-british.inc.php
@@ -5,7 +5,7 @@
  * Encoding:               UTF8
  * Author:                 Alex Butter, The MODx Project Team, The ClipperCMS Project Team
  */
-$_lang["help_msg"] = '<p>You can obtain free community support by <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">visiting the '.CMS_NAME.' Forums</a>. There is also a growing body of <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.' Documentation and Guides</a> that touch on virtually every aspect of '.CMS_NAME.'.</p><p>We are planning to offer commercial support services for '.CMS_NAME.' as well. Please <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Enquiry">email us if you\'re interested</a>.';
+$_lang["help_msg"] = '<p>You can obtain free community support by <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">visiting the '.CMS_NAME.' Forums</a>. There is also a growing body of <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.' Documentation and Guides</a> that touch on virtually every aspect of '.CMS_NAME.'.</p><p>We are planning to offer commercial support services for '.CMS_NAME.' as well. Please <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Enquiry">email us if you\'re interested</a>.';
 $_lang["no_category"] = 'uncategorised';
 $_lang["unauthorizedpage_message"] = 'Enter the ID of the document you want to send users to if they have requested a secured or unauthorised document. <b>NOTE: make sure the ID you\'ve entered belongs to an existing document, and that it has been published and is publicly accessible!</b>';
 $_lang["unauthorizedpage_title"] = 'Unauthorised page:';

--- a/manager/includes/lang/english.inc.php
+++ b/manager/includes/lang/english.inc.php
@@ -352,7 +352,7 @@ $_lang["go"] = 'Go';
 $_lang["group_access_permissions"] = 'User group access';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Help';
-$_lang["help_msg"] = '<p>You can obtain free community support by <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">visiting the '.CMS_NAME.' Forums</a>. There is also a growing body of <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.' Documentation and Guides</a> that touch on virtually every aspect of '.CMS_NAME.'.</p><p>We are planning to offer commercial support services for '.CMS_NAME.' as well. Please <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">email us if you\'re interested</a>.</p>';
+$_lang["help_msg"] = '<p>You can obtain free community support by <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">visiting the '.CMS_NAME.' Forums</a>. There is also a growing body of <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.' Documentation and Guides</a> that touch on virtually every aspect of '.CMS_NAME.'.</p><p>We are planning to offer commercial support services for '.CMS_NAME.' as well. Please <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">email us if you\'re interested</a>.</p>';
 $_lang["help_title"] = 'Help';
 $_lang["hide_tree"] = 'Hide Site Tree';
 $_lang["home"] = 'Home';

--- a/manager/includes/lang/finnish.inc.php
+++ b/manager/includes/lang/finnish.inc.php
@@ -328,7 +328,7 @@ $_lang["go"] = 'OK';
 $_lang["group_access_permissions"] = 'Käyttäjäryhmän oikeudet';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Ohjeet';
-$_lang["help_msg"] = '<p>Ongelmatilanteissa tutustu <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">'.CMS_NAME.':n keskustelufoorumeihin</a>. Lisäksi kannattaa tutustua <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.':n ohjeisiin ja oppaisiin</a> sekä <a href="http://wiki.'.CMS_DOMAIN.'/index.php/Main_Page" target="_blank">'.CMS_NAME.' Wikiin</a>.</p><p>Suunnitteilla on myös kaupallisen '.CMS_NAME.'-tuen tarjoaminen - ota <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">yhteyttä</a>, jos olet kiinnostunut.</p>';
+$_lang["help_msg"] = '<p>Ongelmatilanteissa tutustu <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">'.CMS_NAME.':n keskustelufoorumeihin</a>. Lisäksi kannattaa tutustua <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">'.CMS_NAME.':n ohjeisiin ja oppaisiin</a> sekä <a href="http://wiki.'.CMS_DOMAIN.'/index.php/Main_Page" target="_blank">'.CMS_NAME.' Wikiin</a>.</p><p>Suunnitteilla on myös kaupallisen '.CMS_NAME.'-tuen tarjoaminen - ota <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">yhteyttä</a>, jos olet kiinnostunut.</p>';
 $_lang["help_title"] = 'Ohjeet';
 $_lang["hide_tree"] = 'Piilota sivukartta';
 $_lang["home"] = 'Alkuun';

--- a/manager/includes/lang/francais.inc.php
+++ b/manager/includes/lang/francais.inc.php
@@ -340,7 +340,7 @@ $_lang["go"] = 'Exécuter';
 $_lang["group_access_permissions"] = 'Accès des Groupes d\'Utilisateurs';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Aide';
-$_lang["help_msg"] = '<p>Vous pouvez obtenir de l\'aide en <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">consultant les forums de '.CMS_NAME.'</a>. Il existe également <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">une documentation et des guides pour '.CMS_NAME.'</a> qui abordent tous les aspects de l\'utilisation de '.CMS_NAME.'.</p><p>De plus, nous proposerons bientôt des offres de support commercial. Veuillez <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">nous envoyer un email si vous êtes intéressés</a>.';
+$_lang["help_msg"] = '<p>Vous pouvez obtenir de l\'aide en <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">consultant les forums de '.CMS_NAME.'</a>. Il existe également <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">une documentation et des guides pour '.CMS_NAME.'</a> qui abordent tous les aspects de l\'utilisation de '.CMS_NAME.'.</p><p>De plus, nous proposerons bientôt des offres de support commercial. Veuillez <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">nous envoyer un email si vous êtes intéressés</a>.';
 $_lang["help_title"] = 'Aide';
 $_lang["hide_tree"] = 'Cacher l\'Arbre du Site';
 $_lang["home"] = 'Accueil';

--- a/manager/includes/lang/italian.inc.php
+++ b/manager/includes/lang/italian.inc.php
@@ -343,7 +343,7 @@ $_lang["go"] = 'Vai';
 $_lang["group_access_permissions"] = 'Gruppi di accesso';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Aiuto';
-$_lang["help_msg"] = '<p>Se avete bisogno di aiuto nell\'utilizzo di '.CMS_NAME.', vi consigliamo di visitare i <a href=\'http://'.CMS_DOMAIN.'/forums\' target=\'_blank\'>Forum '.CMS_NAME.'</a>. Inoltre, il sito '.CMS_NAME.' contiene tutta la <a href=\"http://'.CMS_DOMAIN.'/documentation\" target=\"_blank\">documentazione</a> riguardo l\'uso di '.CMS_NAME.' o su come configurarlo, la risposta che state cercando potrebbe essere qui.</p><p>Prevediamo anche di offrire servizi di supporto di tipo commerciale per '.CMS_NAME.'. Se siete interessati, <a href=\"mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\">inviateci un messaggio email</a>.';
+$_lang["help_msg"] = '<p>Se avete bisogno di aiuto nell\'utilizzo di '.CMS_NAME.', vi consigliamo di visitare i <a href=\'http://'.CMS_DOMAIN.'/forum\' target=\'_blank\'>Forum '.CMS_NAME.'</a>. Inoltre, il sito '.CMS_NAME.' contiene tutta la <a href=\"http://'.CMS_DOMAIN.'/documentation\" target=\"_blank\">documentazione</a> riguardo l\'uso di '.CMS_NAME.' o su come configurarlo, la risposta che state cercando potrebbe essere qui.</p><p>Prevediamo anche di offrire servizi di supporto di tipo commerciale per '.CMS_NAME.'. Se siete interessati, <a href=\"mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\">inviateci un messaggio email</a>.';
 $_lang["help_title"] = 'Aiuto';
 $_lang["hide_tree"] = 'Nascondi struttura ad albero';
 $_lang["home"] = 'Inizio';

--- a/manager/includes/lang/nederlands.inc.php
+++ b/manager/includes/lang/nederlands.inc.php
@@ -349,7 +349,7 @@ $_lang["go"] = 'Start';
 $_lang["group_access_permissions"] = 'Groepstoegang';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Help';
-$_lang["help_msg"] = '<p>Voor ondersteuning door de '.CMS_NAME.' gemeenschap kunt u terecht op de <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">'.CMS_NAME.' Forums</a>. Op de '.CMS_NAME.' website kunt u ook <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">documentatie</a> vinden over '.CMS_NAME.'.</p><p>In de toekomst zal er commerci&#235;le ondersteuning mogelijk zijn voor '.CMS_NAME.'. Stuur een <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>e-mail</a> als u interesse heeft.</p>';
+$_lang["help_msg"] = '<p>Voor ondersteuning door de '.CMS_NAME.' gemeenschap kunt u terecht op de <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">'.CMS_NAME.' Forums</a>. Op de '.CMS_NAME.' website kunt u ook <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">documentatie</a> vinden over '.CMS_NAME.'.</p><p>In de toekomst zal er commerci&#235;le ondersteuning mogelijk zijn voor '.CMS_NAME.'. Stuur een <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>e-mail</a> als u interesse heeft.</p>';
 $_lang["help_title"] = 'Help';
 $_lang["hide_tree"] = 'Website boomstructuur verbergen';
 $_lang["home"] = 'Start';

--- a/manager/includes/lang/norsk.inc.php
+++ b/manager/includes/lang/norsk.inc.php
@@ -299,7 +299,7 @@ $_lang["functionnotimpl_message"] = 'Denne funksjonen er ikke implementert enda.
 $_lang["group_access_permissions"] = 'Brukergruppetilgang';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Hjelp';
-$_lang["help_msg"] = '<p>Besøk <a href="http://'.CMS_DOMAIN.'/forums/" target="_blank">'.CMS_NAME.' Forum</a> hvis du trenger hjelp med '.CMS_NAME.'. Der finnes også en voksende mengde <a href="http://'.CMS_DOMAIN.'/documentation" target="blank">dokumentasjon og guider</a> som berører stort sett alle aspekter av '.CMS_NAME.'.</p><p>Vi planlegger også å tilby kommersielle supporttjenester. Send oss en <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>e-postmelding om du er intressert</a>.';
+$_lang["help_msg"] = '<p>Besøk <a href="http://'.CMS_DOMAIN.'/forum/" target="_blank">'.CMS_NAME.' Forum</a> hvis du trenger hjelp med '.CMS_NAME.'. Der finnes også en voksende mengde <a href="http://'.CMS_DOMAIN.'/documentation" target="blank">dokumentasjon og guider</a> som berører stort sett alle aspekter av '.CMS_NAME.'.</p><p>Vi planlegger også å tilby kommersielle supporttjenester. Send oss en <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>e-postmelding om du er intressert</a>.';
 $_lang["help_title"] = 'Hjelp';
 $_lang["hide_tree"] = 'Gjem tre';
 $_lang["home"] = 'Hjem';

--- a/manager/includes/lang/polish.inc.php
+++ b/manager/includes/lang/polish.inc.php
@@ -328,7 +328,7 @@ $_lang["go"] = 'Dalej';
 $_lang["group_access_permissions"] = 'Dostęp grup użytkowników';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Pomoc';
-$_lang["help_msg"] = '<p>Możesz uzyskać darmową pomoc poprzez <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">odwiedzenie Forum '.CMS_NAME.'</a>. Istnieje również wciąż rozwijana <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">Dokumentacja i Instrukcje dla '.CMS_NAME.'\'a</a>, dotyczące praktycznie wszystkich aspektów pracy z '.CMS_NAME.'\'em.</p><p>Planujemy również usługę wsparcia komercyjnego dla '.CMS_NAME.'\'a. <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>Zainteresowanych prosimy o kontakt mailowy</a>.';
+$_lang["help_msg"] = '<p>Możesz uzyskać darmową pomoc poprzez <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">odwiedzenie Forum '.CMS_NAME.'</a>. Istnieje również wciąż rozwijana <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">Dokumentacja i Instrukcje dla '.CMS_NAME.'\'a</a>, dotyczące praktycznie wszystkich aspektów pracy z '.CMS_NAME.'\'em.</p><p>Planujemy również usługę wsparcia komercyjnego dla '.CMS_NAME.'\'a. <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>Zainteresowanych prosimy o kontakt mailowy</a>.';
 $_lang["help_title"] = 'Pomoc';
 $_lang["hide_tree"] = 'Ukryj drzewo';
 $_lang["home"] = 'Start';

--- a/manager/includes/lang/portuguese-br.inc.php
+++ b/manager/includes/lang/portuguese-br.inc.php
@@ -328,7 +328,7 @@ $_lang["go"] = 'Iniciar!';
 $_lang["group_access_permissions"] = 'Permissões de acesso do grupo';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Ajuda';
-$_lang["help_msg"] = '<p>Pode obter ajuda gratuitamente junto da <a href=\'http://'.CMS_DOMAIN.'/forums\' target=\'_blank\'>comunidade que suporta o '.CMS_NAME.'</a>. Existe igualmente um conjunto crescente de <a href=\'http://'.CMS_DOMAIN.'/documentation\' target=\'_blank\'>Documentação e Guias</a> que cobrem muitos aspectos do '.CMS_NAME.'.</p><p>Contamos igualmente oferecer suporte técnico especializado para o '.CMS_NAME.'. Por favor <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>contacte-nos se estiver interessado</a>.</p><p><b>Atenção:</b> atualmente a maior parte da documentação encontra-se apenas disponível em Inglês. Pode contactar alguns falantes de Português que utilizam o '.CMS_NAME.' <a href=\'http://'.CMS_DOMAIN.'/forums/index.php/board,40.0.html\' target=\'_blank\'>na sessão sobre Internacionalização do forum '.CMS_NAME.'</a>.</p>';
+$_lang["help_msg"] = '<p>Pode obter ajuda gratuitamente junto da <a href=\'http://'.CMS_DOMAIN.'/forum\' target=\'_blank\'>comunidade que suporta o '.CMS_NAME.'</a>. Existe igualmente um conjunto crescente de <a href=\'http://'.CMS_DOMAIN.'/documentation\' target=\'_blank\'>Documentação e Guias</a> que cobrem muitos aspectos do '.CMS_NAME.'.</p><p>Contamos igualmente oferecer suporte técnico especializado para o '.CMS_NAME.'. Por favor <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>contacte-nos se estiver interessado</a>.</p>';
 $_lang["help_title"] = 'Ajuda';
 $_lang["hide_tree"] = 'Ocultar árvore';
 $_lang["home"] = 'Início';

--- a/manager/includes/lang/portuguese.inc.php
+++ b/manager/includes/lang/portuguese.inc.php
@@ -294,7 +294,7 @@ $_lang["go"] = 'Iniciar!';
 $_lang["group_access_permissions"] = 'Permissões de acesso do grupo';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Ajuda';
-$_lang["help_msg"] = '<p>Pode obter ajuda gratuitamente junto da <a href=\'http://'.CMS_DOMAIN.'/forums\' target=\'_blank\'>comunidade que suporta o '.CMS_NAME.'</a>. Existe igualmente um conjunto crescente de <a href=\'http://'.CMS_DOMAIN.'/documentation\' target=\'_blank\'>Documentação e Guias</a> que cobrem muitos aspectos do '.CMS_NAME.'.</p><p>Contamos igualmente oferecer suporte técnico especializado para o '.CMS_NAME.'. Por favor <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>contacte-nos se estiver interessado</a>.</p><p><b>Atenção:</b> actualmente a maior parte da documentação encontra-se apenas disponível em Inglês. Pode contactar alguns falantes de Português que utilizam o '.CMS_NAME.' <a href=\'http://'.CMS_DOMAIN.'/forums/index.php/board,40.0.html\' target=\'_blank\'>na secção sobre Internacionalização do forum '.CMS_NAME.'</a>.</p>';
+$_lang["help_msg"] = '<p>Pode obter ajuda gratuitamente junto da <a href=\'http://'.CMS_DOMAIN.'/forum\' target=\'_blank\'>comunidade que suporta o '.CMS_NAME.'</a>. Existe igualmente um conjunto crescente de <a href=\'http://'.CMS_DOMAIN.'/documentation\' target=\'_blank\'>Documentação e Guias</a> que cobrem muitos aspectos do '.CMS_NAME.'.</p><p>Contamos igualmente oferecer suporte técnico especializado para o '.CMS_NAME.'. Por favor <a href=\'mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry\'>contacte-nos se estiver interessado</a>.</p>';
 $_lang["help_title"] = 'Ajuda';
 $_lang["hide_tree"] = 'Ocultar árvore';
 $_lang["home"] = 'Início';

--- a/manager/includes/lang/russian.inc.php
+++ b/manager/includes/lang/russian.inc.php
@@ -339,7 +339,7 @@ $_lang["go"] = 'Перейти';
 $_lang["group_access_permissions"] = 'Доступ групп пользователей';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Помощь';
-$_lang["help_msg"] = '<p>Вы можете получить бесплатную помощь сообщества '.CMS_NAME.' <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">на форумах '.CMS_NAME.'</a>. Смотрите также <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">\'Документация и уроки по '.CMS_NAME.'\'</a>, где подробно описан каждый аспект системы.</p>';
+$_lang["help_msg"] = '<p>Вы можете получить бесплатную помощь сообщества '.CMS_NAME.' <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">на форумах '.CMS_NAME.'</a>. Смотрите также <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">\'Документация и уроки по '.CMS_NAME.'\'</a>, где подробно описан каждый аспект системы.</p>';
 $_lang["help_title"] = 'Помощь';
 $_lang["hide_tree"] = 'Спрятать дерево';
 $_lang["home"] = 'Главная';

--- a/manager/includes/lang/spanish.inc.php
+++ b/manager/includes/lang/spanish.inc.php
@@ -316,7 +316,7 @@ $_lang["go"] = 'Ir';
 $_lang["group_access_permissions"] = 'Acceso de grupo de usuarios';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Ayuda';
-$_lang["help_msg"] = '<p>Puede obtener soporte gratuito de la comunidad <a href="http://'.CMS_DOMAIN.'/forums" target="_blank">visitando los foros de '.CMS_NAME.'</a>.  También hay un cumulo creciente de <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">Documentación y Guías '.CMS_NAME.'</a> que tocan virtualmente todos los aspectos de '.CMS_NAME.'.</p><p>Estamos planeando ofrecer servicios de soporte comercial para '.CMS_NAME.'. Por favor, <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">envíenos un mensaje si está interesado</a>.';
+$_lang["help_msg"] = '<p>Puede obtener soporte gratuito de la comunidad <a href="http://'.CMS_DOMAIN.'/forum" target="_blank">visitando los foros de '.CMS_NAME.'</a>.  También hay un cumulo creciente de <a href="http://'.CMS_DOMAIN.'/documentation" target="_blank">Documentación y Guías '.CMS_NAME.'</a> que tocan virtualmente todos los aspectos de '.CMS_NAME.'.</p><p>Estamos planeando ofrecer servicios de soporte comercial para '.CMS_NAME.'. Por favor, <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">envíenos un mensaje si está interesado</a>.';
 $_lang["help_title"] = 'Ayuda';
 $_lang["hide_tree"] = 'Ocultar árbol';
 $_lang["home"] = 'Inicio';

--- a/manager/includes/lang/svenska.inc.php
+++ b/manager/includes/lang/svenska.inc.php
@@ -340,7 +340,7 @@ $_lang["go"] = 'Utför';
 $_lang["group_access_permissions"] = 'Användargruppsåtkomst';
 $_lang["guid"] = 'GUID';
 $_lang["help"] = 'Hjälp';
-$_lang["help_msg"] = '<p>Besök <a href="http://'.CMS_DOMAIN.'/forums/" target="_blank">'.CMS_NAME.' Forum</a> om du behöver hjälp med '.CMS_NAME.'. Det finns också en växande mängd <a href="http://'.CMS_DOMAIN.'/documentation" target="blank">dokumentation och guider</a> som berör i stort sett alla aspekter av '.CMS_NAME.'.</p><p>Vi planerar också att erbjuda kommersiella supporttjänster. Sänd oss ett <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">e-postmeddelande om du är intresserad</a>.</p>';
+$_lang["help_msg"] = '<p>Besök <a href="http://'.CMS_DOMAIN.'/forum/" target="_blank">'.CMS_NAME.' Forum</a> om du behöver hjälp med '.CMS_NAME.'. Det finns också en växande mängd <a href="http://'.CMS_DOMAIN.'/documentation" target="blank">dokumentation och guider</a> som berör i stort sett alla aspekter av '.CMS_NAME.'.</p><p>Vi planerar också att erbjuda kommersiella supporttjänster. Sänd oss ett <a href="mailto:hello@'.CMS_DOMAIN.'?subject='.CMS_NAME.' Commercial Support Inquiry">e-postmeddelande om du är intresserad</a>.</p>';
 $_lang["help_title"] = 'Hjälp';
 $_lang["hide_tree"] = 'Dölj webbplatsträd';
 $_lang["home"] = 'Hem';

--- a/manager/includes/version.inc.php
+++ b/manager/includes/version.inc.php
@@ -1,5 +1,5 @@
 <?php
-define('CMS_DOMAIN', 'clippercms.org');
+define('CMS_DOMAIN', 'clippercms.com');
 define('CMS_NAME', 'ClipperCMS');
 
 define('CMS_RELEASE_VERSION', '1.2');


### PR DESCRIPTION
Change CMS_DOMAIN form clippercms.org to clippercms.com so links to subdirectories work.
Update language files' Help message element to point to correct URL for current forum.
German left as it is, pointing to clippercms.de, though that redirects to clippercms.com;
Czech updated to English forum instead of MODX Czech boards
Portuguese removed references to Portuguese-language boards

NB Hebrew has no relevant entry
Chinese, Japanese & Persian not updated.
