### PR TITLE
fix styles for chrome safari

### DIFF
--- a/manager/actions/mutate_htmlsnippet.dynamic.php
+++ b/manager/actions/mutate_htmlsnippet.dynamic.php
@@ -150,14 +150,14 @@ if (is_array($evtOut))
 
 <div class="sectionBody">
     <p><?php echo $_lang['htmlsnippet_msg']?></p>
-    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <table width="100%" border="0">
         <tr><td align="left"><?php echo $_lang['htmlsnippet_name']?>:</td>
-            <td align="left"><span style="font-family:'Courier New', Courier, mono">{{</span><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name'])?>" class="inputBox" style="width:140px;" onChange='documentDirty=true;'><span style="font-family:'Courier New', Courier, mono">}}</span><span class="warning" id="savingMessage">&nbsp;</span></td></tr>
+            <td align="left"><span class="chunk-tag"><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name'])?>" class="inputBox"  onChange='documentDirty=true;'></span><span class="warning" id="savingMessage">&nbsp;</span></td></tr>
         <tr><td align="left"><?php echo $_lang['htmlsnippet_desc']?>:&nbsp;&nbsp;</td>
-            <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="description" type="text" maxlength="255" value="<?php echo htmlspecialchars($content['description'])?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td></tr>
+            <td align="left"><input name="description" type="text" maxlength="255" value="<?php echo htmlspecialchars($content['description'])?>" class="inputBox" onChange='documentDirty=true;'></td></tr>
         <tr><td align="left"><?php echo $_lang['existing_category']?>:&nbsp;&nbsp;</td>
-            <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span>
-            <select name="categoryid" style="width:300px;" onChange='documentDirty=true;'>
+            <td align="left">
+            <select name="categoryid" onChange='documentDirty=true;'>
                 <option>&nbsp;</option>
 <?php
 include_once(MODX_MANAGER_PATH.'includes/categories.inc.php');
@@ -169,8 +169,8 @@ if ($ds) {
 }
 ?>
             </select></td></tr>
-        <tr><td align="left" valign="top" style="padding-top:5px;"><?php echo $_lang['new_category']?>:</td>
-            <td align="left" valign="top" style="padding-top:5px;"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="newcategory" type="text" maxlength="45" value="<?php echo isset($content['newcategory']) ? $content['newcategory'] : ''?>" class="inputBox" style="width:300px;" onChange="documentDirty=true;"></td></tr>
+        <tr><td align="left"><?php echo $_lang['new_category']?>:</td>
+            <td align="left"><input name="newcategory" type="text" maxlength="45" value="<?php echo isset($content['newcategory']) ? $content['newcategory'] : ''?>" class="inputBox" onChange="documentDirty=true;"></td></tr>
         <tr><td align="left" colspan="2"><input name="locked" type="checkbox"<?php echo $content['locked'] == 1 || $content['locked'] == 'on' ? ' checked="checked"' : ''?> class="inputBox" value="on" /> <?php echo $_lang['lock_htmlsnippet']?>
             <span class="comment"><?php echo $_lang['lock_htmlsnippet_msg']?></span></td></tr>
     </table>

--- a/manager/actions/mutate_module.dynamic.php
+++ b/manager/actions/mutate_module.dynamic.php
@@ -141,7 +141,7 @@ function showParameters(ctrl) {
 	dp = (f.properties.value) ? f.properties.value.split("&"):"";
 	if(!dp) tr.style.display='none';
 	else {
-		t='<table style="margin-bottom:3px;margin-left:14px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td><?php echo $_lang['parameter']?></td><td><?php echo $_lang['value']?></td></tr></thead>';
+		t='<table style="margin-bottom:3px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td><?php echo $_lang['parameter']?></td><td><?php echo $_lang['value']?></td></tr></thead>';
 		for(p = 0; p < dp.length; p++) {
 			dp[p]=(dp[p]+'').replace(/^\s|\s$/,""); // trim
 			ar = dp[p].split("=");
@@ -369,15 +369,15 @@ function SetUrl(url, width, height, alt) {
 		<!-- General -->
 		<div id="tabModule">
 		
-			<table border="0" cellspacing="0" cellpadding="1">
+			<table border="0" width="100%">
 				<tr><td align="left"><?php echo $_lang['module_name']?>:</td>
-					<td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name'])?>" class="inputBox" style="width:150px;" onchange="documentDirty=true;"><span style="font-family:'Courier New', Courier, mono">&nbsp;</span><span class="warning" id="savingMessage">&nbsp;</span></td></tr>
+					<td align="left"><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name'])?>" class="inputBox" style="width:150px;" onchange="documentDirty=true;"><span style="font-family:'Courier New', Courier, mono">&nbsp;</span><span class="warning" id="savingMessage">&nbsp;</span></td></tr>
 				<tr><td align="left"><?php echo $_lang['module_desc']?>:&nbsp;&nbsp;</td>
-					<td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="description" type="text" maxlength="255" value="<?php echo $content['description']?>" class="inputBox" onchange="documentDirty=true;"></td></tr>
+					<td align="left"><input name="description" type="text" maxlength="255" value="<?php echo $content['description']?>" class="inputBox" onchange="documentDirty=true;"></td></tr>
 				<tr><td align="left"><?php echo $_lang['icon']?> <span class="comment">(32x32)</span>:&nbsp;&nbsp;</td>
-					<td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input onchange="documentDirty=true;" type="text" maxlength="255" style="width: 235px;" name="icon" value="<?php echo $content['icon']?>" /> <input type="button" value="<?php echo $_lang['insert']?>" onclick="BrowseServer();" /></td></tr>
+					<td align="left"><input onchange="documentDirty=true;" type="text" maxlength="255" style="width: 235px;" name="icon" value="<?php echo $content['icon']?>" /> <input type="button" value="<?php echo $_lang['insert']?>" onclick="BrowseServer();" /></td></tr>
 				<tr><td align="left"><?php echo $_lang['existing_category']?>:&nbsp;&nbsp;</td>
-					<td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span>
+					<td align="left">
 					<select name="categoryid" onchange="documentDirty=true;">
 						<option>&nbsp;</option>
 		<?php
@@ -390,24 +390,22 @@ function SetUrl(url, width, height, alt) {
 						}
 		?>
 					</select></td></tr>
-				<tr><td align="left" valign="top" style="padding-top:5px;"><?php echo $_lang['new_category']?>:</td>
-					<td align="left" valign="top" style="padding-top:5px;"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" onchange="documentDirty=true;"></td></tr>
+				<tr><td align="left"><?php echo $_lang['new_category']?>:</td>
+					<td align="left"><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" onchange="documentDirty=true;"></td></tr>
 				<tr><td align="left"><input name="enable_resource" title="<?php echo $_lang['enable_resource']?>" type="checkbox"<?php echo $content['enable_resource']==1 ? ' checked="checked"' : ''?> class="inputBox" onclick="documentDirty=true;" /> <span style="cursor:pointer" onclick="document.mutate.enable_resource.click();" title="<?php echo $_lang['enable_resource']?>"><?php echo $_lang["element"]?></span>:</td>
-					<td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="sourcefile" type="text" maxlength="255" value="<?php echo $content['sourcefile']?>" class="inputBox" onchange="documentDirty=true;" /></td></tr>
-				<tr><td align="left" valign="top" colspan="2"><input name="disabled" type="checkbox" <?php echo $content['disabled'] == 1 ? 'checked="checked"' : ''?> value="on" class="inputBox" />
+					<td align="left"><input name="sourcefile" type="text" maxlength="255" value="<?php echo $content['sourcefile']?>" class="inputBox" onchange="documentDirty=true;" /></td></tr>
+				<tr><td align="left" colspan="2"><input name="disabled" type="checkbox" <?php echo $content['disabled'] == 1 ? 'checked="checked"' : ''?> value="on" class="inputBox" />
 					<span style="cursor:pointer" onclick="document.mutate.disabled.click();"><?php echo  $content['disabled'] == 1 ? '<span class="warning">'.$_lang['module_disabled'].'</span>' : $_lang['module_disabled']?></span></td></tr>
-				<tr><td align="left" valign="top" colspan="2"><input name="locked" type="checkbox"<?php echo $content['locked'] == 1 ? ' checked="checked"' : ''?> class="inputBox" />
+				<tr><td align="left" colspan="2"><input name="locked" type="checkbox"<?php echo $content['locked'] == 1 ? ' checked="checked"' : ''?> class="inputBox" />
 					<span style="cursor:pointer" onclick="document.mutate.locked.click();"><?php echo $_lang['lock_module']?></span> <span class="comment"><?php echo $_lang['lock_module_msg']?></span></td></tr>
 			</table>
 		
 			<!-- PHP text editor start -->
-			<div style="width:100%; position:relative">
-				<div style="padding:1px; width:100%; height:16px; background-color:#eeeeee; border-top:1px solid #e0e0e0; margin-top:5px">
-					<span style="float:left; color:#707070; font-weight:bold; padding:3px">&nbsp;<?php echo $_lang['module_code']?></span>
-					<span style="float:right; color:#707070"><?php echo $_lang['wrap_lines']?><input name="wrap" type="checkbox"<?php echo $content['wrap']== 1 ? ' checked="checked"' : ''?> class="inputBox" onclick="setTextWrap(document.mutate.post,this.checked)" /></span>
-				</div>
-				<textarea dir="ltr" class="phptextarea" name="post" style="width:98%; height:370px;" wrap="<?php echo $content['wrap']== 1 ? 'soft' : 'off'?>" onchange="documentDirty=true;"><?php echo htmlspecialchars($content['modulecode'])?></textarea>
+			<div>
+				<h2 class="editor-heading"><?php echo $_lang['module_code']?>
+				<span class="pull-right"><?php echo $_lang['wrap_lines']?><input name="wrap" type="checkbox"<?php echo $content['wrap']== 1 ? ' checked="checked"' : ''?> class="inputBox" onclick="setTextWrap(document.mutate.post,this.checked)" /></span>
 			</div>
+			<textarea dir="ltr" class="phptextarea" name="post" style="width:98%; height:370px;" wrap="<?php echo $content['wrap']== 1 ? 'soft' : 'off'?>" onchange="documentDirty=true;"><?php echo htmlspecialchars($content['modulecode'])?></textarea>
 			<!-- PHP text editor end -->
 	
 		</div> <!-- General -->
@@ -416,14 +414,20 @@ function SetUrl(url, width, height, alt) {
 		<!-- Configuration -->
 		<div id="tabConfig">
 			
-			<table width="90%" border="0" cellspacing="0" cellpadding="0">
-				<tr><td align="left" valign="top"><?php echo $_lang['guid']?>:</td>
-					<td align="left" valign="top"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="guid" type="text" maxlength="32" value="<?php echo (int) $_REQUEST['a'] == 107 ? createGUID() : $content['guid']?>" class="inputBox" onchange="documentDirty=true;" /><br /><br /></td></tr>
-				<tr><td align="left" valign="top"><input name="enable_sharedparams" type="checkbox"<?php echo $content['enable_sharedparams']==1 ? ' checked="checked"' : ''?> class="inputBox" onclick="documentDirty=true;" /> <span style="cursor:pointer" onclick="document.mutate.enable_sharedparams.click();"><?php echo $_lang['enable_sharedparams']?>:</span></td>
-					<td align="left" valign="top"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><span ><span class="comment"><?php echo $_lang['enable_sharedparams_msg']?></span></span><br /><br /></td></tr>
-				<tr><td align="left" valign="top"><?php echo $_lang['module_config']?>:</td>
-					<td align="left" valign="top"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="properties" type="text" maxlength="65535" value="<?php echo $content['properties']?>" class="inputBox phptextarea" style="width:280px;" onchange="showParameters(this);documentDirty=true;" /><input type="button" value="<?php echo $_lang['update_params'] ?>" style="width:16px; margin-left:2px;" title="<?php echo $_lang['update_params']?>" /></td></tr>
-				<tr id="displayparamrow"><td valign="top" align="left">&nbsp;</td>
+			<table width="100%" border="0">
+				<tr><td align="left"><?php echo $_lang['guid']?>:</td>
+					<td align="left"><input name="guid" type="text" maxlength="32" value="<?php echo (int) $_REQUEST['a'] == 107 ? createGUID() : $content['guid']?>" class="inputBox" onchange="documentDirty=true;" />
+				</td></tr>
+				<tr>
+					<td colspan="2"><div class="comment"><?php echo $_lang['enable_sharedparams_msg']?></div></td>
+				</tr>
+				<tr><td colspan="2"><div class="split"></div></td></tr>
+				<tr><td align="left" colspan="2"><input name="enable_sharedparams" type="checkbox"<?php echo $content['enable_sharedparams']==1 ? ' checked="checked"' : ''?> class="inputBox" onclick="documentDirty=true;" /> <span style="cursor:pointer" onclick="document.mutate.enable_sharedparams.click();"><?php echo $_lang['enable_sharedparams']?>:</span>
+				</td>
+				</tr>
+				<tr><td align="left"><?php echo $_lang['module_config']?>:</td>
+					<td align="left"><input name="properties" type="text" maxlength="65535" value="<?php echo $content['properties']?>" class="inputBox phptextarea" style="width:280px;" onchange="showParameters(this);documentDirty=true;" /><input type="button" value="<?php echo $_lang['update_params'] ?>" style="width:16px; margin-left:2px;" title="<?php echo $_lang['update_params']?>" /></td></tr>
+				<tr id="displayparamrow"><td align="left">&nbsp;</td>
 					<td align="left" id="displayparams">&nbsp;</td></tr>
 			</table>
 			
@@ -436,9 +440,9 @@ function SetUrl(url, width, height, alt) {
 			
 			<table width="95%" border="0" cellspacing="0" cellpadding="0">
 				<tr>
-					<td align="left" valign="top"><p><?php echo $_lang['module_viewdepend_msg']?><br /><br />
+					<td align="left"><p><?php echo $_lang['module_viewdepend_msg']?><br /><br />
 					<a class="searchtoolbarbtn" href="#" style="float:left" onclick="loadDependencies();return false;"><img src="<?php echo $_style["icons_save"]?>" align="absmiddle" /> <?php echo $_lang['manage_depends']?></a><br /><br /></p></td></tr>
-				<tr><td valign="top" align="left">
+				<tr><td align="left">
 			<?php
 				$sql = 'SELECT smd.id, COALESCE(ss.name,st.templatename,sv.name,sc.name,sp.name,sd.pagetitle) AS `name`, '.
 						'CASE smd.type'.

--- a/manager/actions/mutate_plugin.dynamic.php
+++ b/manager/actions/mutate_plugin.dynamic.php
@@ -102,7 +102,7 @@ function showParameters(ctrl) {
 	dp = (f.properties.value) ? f.properties.value.split("&"):"";
 	if(!dp) tr.style.display='none';
 	else {
-		t='<table width="300" style="margin-bottom:3px;margin-left:14px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td width="50%"><?php echo $_lang['parameter']; ?></td><td width="50%"><?php echo $_lang['value']; ?></td></tr></thead>';
+		t='<table width="300" style="margin-bottom:3px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td width="50%"><?php echo $_lang['parameter']; ?></td><td width="50%"><?php echo $_lang['value']; ?></td></tr></thead>';
 		for(p = 0; p < dp.length; p++) {
 			dp[p]=(dp[p]+'').replace(/^\s|\s$/,""); // trim
 			ar = dp[p].split("=");
@@ -306,14 +306,14 @@ if(is_array($evtOut)) echo implode("",$evtOut);
 		<!-- General -->
 		<div id="tabSnippet">
 			
-			<table border="0" cellspacing="0" cellpadding="0">
+			<table border="0" width="100%">
 			  <tr>
 				<td align="left"><?php echo $_lang['plugin_name']; ?>:</td>
-				<td align="left"><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name']);?>" class="inputBox" style="width:150px;" onChange='documentDirty=true;'><span class="warning" id='savingMessage'>&nbsp;</span></td>
+				<td align="left"><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name']);?>" class="inputBox" onChange='documentDirty=true;'></td>
 			  </tr>
 			  <tr>
 				<td align="left"><?php echo $_lang['plugin_desc']; ?>:&nbsp;&nbsp;</td>
-				<td align="left"><input name="description" type="text" maxlength="255" value="<?php echo $content['description'];?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+				<td align="left"><input name="description" type="text" maxlength="255" value="<?php echo $content['description'];?>" class="inputBox" onChange='documentDirty=true;'></td>
 			  </tr>
 			  <tr>
 				<td align="left" valign="top" colspan="2"><input name="disabled" type="checkbox" <?php echo $content['disabled']==1 ? "checked='checked'" : "";?> value="on" class="inputBox"> <?php echo  $content['disabled']==1 ? "<span class='warning'>".$_lang['plugin_disabled']."</span>":$_lang['plugin_disabled']; ?></td>
@@ -325,9 +325,9 @@ if(is_array($evtOut)) echo implode("",$evtOut);
 			
 			<!-- PHP text editor start -->
 			<div style="width:100%;position:relative">
-				<div style="padding:1px; width:100%; height:16px;background-color:#eeeeee; border-top:1px solid #e0e0e0;margin-top:5px">
-					<span style="float:left;color:#707070;font-weight:bold; padding:3px">&nbsp;<?php echo $_lang['plugin_code']; ?></span>
-					<span style="float:right;color:#707070;"><?php echo $_lang['wrap_lines']; ?><input name="wrap" type="checkbox" <?php echo $content['wrap']== 1 ? "checked='checked'" : "" ;?> class="inputBox" onclick="setTextWrap(document.mutate.post,this.checked)" /></span>
+				<div>
+					<h2 class="editor-heading"><?php echo $_lang['plugin_code']?>
+					<span class="pull-right"><?php echo $_lang['wrap_lines']; ?><input name="wrap" type="checkbox" <?php echo $content['wrap']== 1 ? "checked='checked'" : "" ;?> class="inputBox" onclick="setTextWrap(document.mutate.post,this.checked)" /></span>
 				</div>
 				<textarea dir="ltr" name="post" class="phptextarea" style="width:98%; height:370px;" wrap="<?php echo $content['wrap']== 1 ? "soft" : "off" ;?>" onchange="documentDirty=true;"><?php echo htmlspecialchars($content['plugincode']); ?></textarea>
 			</div>
@@ -337,10 +337,10 @@ if(is_array($evtOut)) echo implode("",$evtOut);
 		<!-- Configuration/Properties -->
 		<div id="tabProps">
 			
-			<table width="90%" border="0" cellspacing="0" cellpadding="0">
+			<table width="100%" border="0">
 			  <tr>
 				<td align="left"><?php echo $_lang['existing_category']; ?>:&nbsp;&nbsp;</td>
-				<td align="left"><select name="categoryid" style="width:300px;" onChange='documentDirty=true;'>
+				<td align="left"><select name="categoryid" onChange='documentDirty=true;'>
 					<option>&nbsp;</option>
 					<?php
 						include_once "categories.inc.php";
@@ -353,12 +353,12 @@ if(is_array($evtOut)) echo implode("",$evtOut);
 				</td>
 			  </tr>
 			  <tr>
-				<td align="left" valign="top" style="padding-top:5px;"><?php echo $_lang['new_category']; ?>:</td>
-				<td align="left" valign="top" style="padding-top:5px;"><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+				<td align="left"><?php echo $_lang['new_category']; ?>:</td>
+				<td align="left"><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
 			  </tr>
 			  <tr>
 				<td align="left"><?php echo $_lang['import_params']; ?>:&nbsp;&nbsp;</td>
-				<td align="left"><select name="moduleguid" style="width:300px;" onChange='documentDirty=true;'>
+				<td align="left"><select name="moduleguid" onChange='documentDirty=true;'>
 					<option>&nbsp;</option>
 					<?php
 						$sql =	"SELECT sm.id,sm.name,sm.guid " .
@@ -381,7 +381,7 @@ if(is_array($evtOut)) echo implode("",$evtOut);
 			  </tr>
 			  <tr>
 				<td align="left" valign="top"><?php echo $_lang['plugin_config']; ?>:</td>
-				<td align="left" valign="top"><textarea class="phptextarea" name="properties" onChange='showParameters(this);documentDirty=true;'><?php echo $content['properties'];?></textarea><br /><input type="button" value="<?php echo $_lang['update_params']; ?>" /></td>
+				<td align="left" valign="top"><textarea class="phptextarea" name="properties" onChange='showParameters(this);documentDirty=true;'><?php echo $content['properties'];?></textarea> <br/><br/><input type="button" value="<?php echo $_lang['update_params']; ?>"/></td>
 			  </tr>
 			  <tr id="displayparamrow">
 				<td valign="top" align="left">&nbsp;</td>

--- a/manager/actions/mutate_settings.dynamic.php
+++ b/manager/actions/mutate_settings.dynamic.php
@@ -205,7 +205,7 @@ function confirmLangChange(el, lkey, elupd){
                     </tr>
                   <tr>
                     <th><?php echo $_lang["charset_title"]?></th>
-                    <td> <select name="modx_charset" size="1" class="inputBox" style="width:250px;" onchange="documentDirty=true;">
+                    <td> <select name="modx_charset" size="1" class="inputBox" onchange="documentDirty=true;">
                         <?php include "charsets.php"; ?>
                       </select> </td>
                   </tr>

--- a/manager/actions/mutate_snippet.dynamic.php
+++ b/manager/actions/mutate_snippet.dynamic.php
@@ -107,7 +107,7 @@ function showParameters(ctrl) {
     dp = (f.properties.value) ? f.properties.value.split("&"):"";
     if(!dp) tr.style.display='none';
     else {
-        t='<table width="300" style="margin-bottom:3px;margin-left:14px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td width="50%"><?php echo $_lang['parameter']?></td><td width="50%"><?php echo $_lang['value']?></td></tr></thead>';
+        t='<table width="300" style="margin-bottom:3px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td width="50%"><?php echo $_lang['parameter']?></td><td width="50%"><?php echo $_lang['value']?></td></tr></thead>';
         for(p = 0; p < dp.length; p++) {
             dp[p]=(dp[p]+'').replace(/^\s|\s$/,""); // trim
             ar = dp[p].split("=");
@@ -301,25 +301,26 @@ function decode(s){
 		<div id="tabSnippet">
 		
 			<h2 class="tab"><?php echo $_lang['settings_general']?></h2>
-	        <table border="0" cellspacing="0" cellpadding="0">
+			
+	        <table border="0" width="100%">
 	          <tr>
 	            <td align="left"><?php echo $_lang['snippet_name']?>:</td>
-	            <td align="left"><span style="font-family:'Courier New', Courier, mono">[[</span><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name'])?>" class="inputBox" style="width:150px;" onChange="documentDirty=true;"><span style="font-family:'Courier New', Courier, mono">]]</span><span class="warning" id="savingMessage">&nbsp;</span></td>
+	            <td align="left"><span class="snippet-tag"><input name="name" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['name'])?>" class="inputBox" onChange="documentDirty=true;"></span></td>
 	          </tr>
 	          <tr>
-	            <td align="left" style="padding-top:10px"><?php echo $_lang['snippet_desc']?>:&nbsp;&nbsp;</td>
-	            <td align="left" style="padding-top:10px"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="description" type="text" maxlength="255" value="<?php echo $content['description']?>" class="inputBox" style="width:300px;" onChange="documentDirty=true;"></td>
+	            <td align="left"><?php echo $_lang['snippet_desc']?>:&nbsp;&nbsp;</td>
+	            <td align="left"><input name="description" type="text" maxlength="255" value="<?php echo $content['description']?>" class="inputBox" onChange="documentDirty=true;"></td>
 	          </tr>
 	          <tr>
-	            <td style="padding-top:10px" align="left" valign="top" colspan="2"><input style="padding:0;margin:0;" name="locked" type="checkbox" <?php echo $content['locked']==1 ? "checked='checked'" : ""?> class="inputBox"> <?php echo $_lang['lock_snippet']?> <span class="comment"><?php echo $_lang['lock_snippet_msg']?></span></td>
+	            <td align="left" valign="top" colspan="2"><input name="locked" type="checkbox" <?php echo $content['locked']==1 ? "checked='checked'" : ""?> class="inputBox"> <?php echo $_lang['lock_snippet']?> <span class="comment"><?php echo $_lang['lock_snippet_msg']?></span></td>
 	          </tr>
 	        </table>
 	        <!-- PHP text editor start -->
-	        <div style="width:100%;position:relative">
-	            <div style="padding:1px 1px 5px 1px; width:100%; height:16px;background-color:#eeeeee; border-top:1px solid #e0e0e0;margin-top:5px">
-	                <span style="float:left;color:#707070;font-weight:bold; padding:3px">&nbsp;<?php echo $_lang['snippet_code']?></span>
-	                <span style="float:right;color:#707070;"><?php echo $_lang['wrap_lines']?><input name="wrap" type="checkbox" <?php echo $content['wrap']== 1 ? "checked='checked'" : ""?> class="inputBox" onclick="setTextWrap(document.mutate.post,this.checked)" /></span>
-	            </div>
+	        <div>
+	            <h2 class="editor-heading"><?php echo $_lang['snippet_code']?>
+	            <span class="pull-right"><?php echo $_lang['wrap_lines']?><input name="wrap" type="checkbox" <?php echo $content['wrap']== 1 ? "checked='checked'" : ""?> class="inputBox" onclick="setTextWrap(document.mutate.post,this.checked)" /></span>
+	            </h2>
+	            
 	            <textarea dir="ltr" name="post" class="phptextarea" style="width:98%; height:370px;" wrap="<?php echo $content['wrap']== 1 ? "soft" : "off"?>" onchange="documentDirty=true;"><?php echo "<?php"."\n".trim(htmlspecialchars($content['snippet']))."\n"."?>"?></textarea>
 	        </div>
 	        <!-- PHP text editor end -->
@@ -329,10 +330,10 @@ function decode(s){
 		<div id="tabProps">
 			
 			<h2 class="tab"><?php echo $_lang['settings_properties']?></h2>
-	        <table width="90%" border="0" cellspacing="0" cellpadding="0">
+	        <table width="100%" border="0">
 	          <tr>
 	            <td align="left"><?php echo $_lang['existing_category']?>:&nbsp;&nbsp;</td>
-	            <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><select name="categoryid" style="width:300px;" onChange="documentDirty=true;">
+	            <td align="left"><select name="categoryid" onChange="documentDirty=true;">
 	                    <option>&nbsp;</option>
 	                <?php
 	                    include_once "categories.inc.php";
@@ -345,12 +346,12 @@ function decode(s){
 	            </td>
 	          </tr>
 	          <tr>
-	            <td align="left" valign="top" style="padding-top:10px;"><?php echo $_lang['new_category']?>:</td>
-	            <td align="left" valign="top" style="padding-top:10px;"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" style="width:300px;" onChange="documentDirty=true;"></td>
+	            <td align="left"><?php echo $_lang['new_category']?>:</td>
+	            <td align="left"><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" onChange="documentDirty=true;"></td>
 	          </tr>
 	          <tr>
-	            <td align="left" style="padding-top:10px;"><?php echo $_lang['import_params']?>:&nbsp;&nbsp;</td>
-	            <td align="left" valign="top" style="padding-top:10px;"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><select name="moduleguid" style="width:300px;" onChange="documentDirty=true;">
+	            <td align="left"><?php echo $_lang['import_params']?>:&nbsp;&nbsp;</td>
+	            <td align="left"><select name="moduleguid" onChange="documentDirty=true;">
 	                    <option>&nbsp;</option>
 	                <?php
 	                    $sql = 'SELECT sm.id,sm.name,sm.guid '.
@@ -369,11 +370,11 @@ function decode(s){
 	          </tr>
 	          <tr>
 	            <td>&nbsp;</td>
-	            <td align="left" valign="top" style="padding-left:1.3em;"><span class="comment" ><?php echo $_lang['import_params_msg']?></div><br /><br /></td>
+	            <td align="left" valign="top"><span class="comment" ><?php echo $_lang['import_params_msg']?></div><br /><br /></td>
 	          </tr>
 	          <tr>
 	            <td align="left" valign="top"><?php echo $_lang['snippet_properties']?>:</td>
-	            <td align="left" valign="top"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="properties" type="text" maxlength="65535" value="<?php echo $content['properties']?>" class="inputBox phptextarea" style="width:300px;" onChange="showParameters(this);documentDirty=true;"></td>
+	            <td align="left" valign="top"><input name="properties" type="text" maxlength="65535" value="<?php echo $content['properties']?>" class="inputBox phptextarea" onChange="showParameters(this);documentDirty=true;"></td>
 	          </tr>
 	          <tr id="displayparamrow">
 	            <td valign="top" align="left">&nbsp;</td>

--- a/manager/actions/mutate_templates.dynamic.php
+++ b/manager/actions/mutate_templates.dynamic.php
@@ -146,22 +146,22 @@ function deletedocument() {
 	<?php } ?>
 			
 			<?php echo "\t" . $_lang['template_msg']; ?>
-		    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+		    <table width="100%" border="0" >
 		      <tr>
 		        <td align="left"><img src="<?php echo $_style['tx']; ?>" width="100" height="1" /></td>
 		        <td align="left">&nbsp;</td>
 		      </tr>
 		      <tr>
 		        <td align="left"><?php echo $_lang['template_name']; ?>:&nbsp;&nbsp;</td>
-		        <td align="left"><input name="templatename" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['templatename']);?>" class="inputBox" style="width:150px;" onChange='documentDirty=true;'><span class="warning" id='savingMessage'></span></td>
+		        <td align="left"><input name="templatename" type="text" maxlength="100" value="<?php echo htmlspecialchars($content['templatename']);?>" class="inputBox" onChange='documentDirty=true;'><span class="warning" id='savingMessage'></span></td>
 		      </tr>
 		        <tr>
 		        <td align="left"><?php echo $_lang['template_desc']; ?>:&nbsp;&nbsp;</td>
-		        <td align="left"><input name="description" type="text" maxlength="255" value="<?php echo htmlspecialchars($content['description']);?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+		        <td align="left"><input name="description" type="text" maxlength="255" value="<?php echo htmlspecialchars($content['description']);?>" class="inputBox" onChange='documentDirty=true;'></td>
 		      </tr>
 		      <tr>
 		        <td align="left"><?php echo $_lang['existing_category']; ?>:&nbsp;&nbsp;</td>
-		        <td align="left"><select name="categoryid" style="width:300px;" onChange='documentDirty=true;'>
+		        <td align="left"><select name="categoryid" onChange='documentDirty=true;'>
 		                <option>&nbsp;</option>
 		                <?php
 		                    include_once "categories.inc.php";
@@ -175,7 +175,7 @@ function deletedocument() {
 		      </tr>
 		      <tr>
 		        <td align="left"><?php echo $_lang['new_category']; ?>:</td>
-		        <td align="left"><input name="newcategory" type="text" maxlength="45" value="<?php echo isset($content['newcategory']) ? $content['newcategory'] : '' ?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+		        <td align="left"><input name="newcategory" type="text" maxlength="45" value="<?php echo isset($content['newcategory']) ? $content['newcategory'] : '' ?>" class="inputBox" onChange='documentDirty=true;'></td>
 		      </tr>
 		      <tr>
 		        <td align="left"><?php echo $_lang['default_child_template']; ?>:</td>

--- a/manager/actions/mutate_tmplvars.dynamic.php
+++ b/manager/actions/mutate_tmplvars.dynamic.php
@@ -133,7 +133,7 @@ function showParameters(ctrl) {
     dp = (widgetParams[df]) ? widgetParams[df].split("&"):"";
     if(!dp) tr.style.display='none';
     else {
-        t='<table width="300" style="margin-bottom:3px;margin-left:14px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td width="50%"><?php echo $_lang['parameter']; ?></td><td width="50%"><?php echo $_lang['value']; ?></td></tr></thead>';
+        t='<table width="300" style="margin-bottom:3px;background-color:#EEEEEE" cellpadding="2" cellspacing="1"><thead><tr><td width="50%"><?php echo $_lang['parameter']; ?></td><td width="50%"><?php echo $_lang['value']; ?></td></tr></thead>';
         for(p = 0; p < dp.length; p++) {
             dp[p]=(dp[p]+'').replace(/^\s|\s$/,""); // trim
             ar = dp[p].split("=");
@@ -278,24 +278,24 @@ function decode(s){
 
 <div class="sectionBody">
 <p><?php echo $_lang['tmplvars_msg']; ?></p>
-<table width="100%" cellspacing="0" cellpadding="0" border="0">
+<table width="100%" cellspacing="0">
   <tr>
     <td align="left"><?php echo $_lang['tmplvars_name']; ?>:</td>
-    <td align="left"><span style="font-family:'Courier New', Courier, mono">[*</span><input name="name" type="text" maxlength="50" value="<?php echo htmlspecialchars($content['name']);?>" class="inputBox" style="width:150px;" onChange='documentDirty=true;'><span style="font-family:'Courier New', Courier, mono">*]</span> <span class="warning" id='savingMessage'>&nbsp;</span></td>
+    <td align="left"><span class="tv-tag"><input name="name" type="text" maxlength="50" value="<?php echo htmlspecialchars($content['name']);?>" class="inputBox" onChange='documentDirty=true;'></span></td>
   </tr>
   <tr>
     <td align="left"><?php echo $_lang['tmplvars_caption']; ?>:&nbsp;&nbsp;</td>
-    <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="caption" type="text" maxlength="80" value="<?php echo htmlspecialchars($content['caption']);?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+    <td align="left"><input name="caption" type="text" maxlength="80" value="<?php echo htmlspecialchars($content['caption']);?>" class="inputBox" onChange='documentDirty=true;'></td>
   </tr>
 
   <tr>
     <td align="left"><?php echo $_lang['tmplvars_description']; ?>:&nbsp;&nbsp;</td>
-    <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="description" type="text" maxlength="255" value="<?php echo htmlspecialchars($content['description']);?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+    <td align="left"><input name="description" type="text" maxlength="255" value="<?php echo htmlspecialchars($content['description']);?>" class="inputBox" onChange='documentDirty=true;'></td>
   </tr>
 
   <tr>
     <td align="left"><?php echo $_lang['tmplvars_type']; ?>:&nbsp;&nbsp;</td>
-    <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><select name="type" size="1" class="inputBox" style="width:300px;" onChange='documentDirty=true;'>
+    <td align="left"><select name="type" size="1" onChange='documentDirty=true;'>
 	            <option value="text" <?php      echo ($content['type']==''||$content['type']=='text')? "selected='selected'":""; ?>>Text</option>
 	            <option value="textarea" <?php  echo ($content['type']=='textarea')? "selected='selected'":""; ?>>Textarea</option>
 	            <option value="textareamini" <?php  echo ($content['type']=='textareamini')? "selected='selected'":""; ?>>Textarea (Mini)</option>
@@ -317,16 +317,16 @@ function decode(s){
   </tr>
   <tr>
 	<td align="left" valign="top"><?php echo $_lang['tmplvars_elements']; ?>:  </td>
-	<td align="left" nowrap="nowrap"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><textarea name="elements" maxlength="65535" class="inputBox textarea" onchange='documentDirty=true;'><?php echo htmlspecialchars($content['elements']);?></textarea><img src="<?php echo $_style["icons_tooltip"]?>" title="<?php echo $_lang['tmplvars_binding_msg']; ?>" class="tooltip" /></td>
+	<td align="left" nowrap="nowrap"><textarea name="elements" maxlength="65535" class="inputBox textarea" onchange='documentDirty=true;'><?php echo htmlspecialchars($content['elements']);?></textarea><img src="<?php echo $_style["icons_tooltip"]?>" title="<?php echo $_lang['tmplvars_binding_msg']; ?>" class="tooltip" /></td>
   </tr>
   <tr>
     <td align="left" valign="top"><?php echo $_lang['tmplvars_default']; ?>:&nbsp;&nbsp;</td>
-    <td align="left" nowrap="nowrap"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><textarea name="default_text" type="text" class="inputBox" rows="5" style="width:300px;" onChange='documentDirty=true;'><?php echo htmlspecialchars($content['default_text']);?></textarea><img src="<?php echo $_style["icons_tooltip"]?>" title="<?php echo $_lang['tmplvars_binding_msg']; ?>" class="tooltip" /></td>
+    <td align="left" nowrap="nowrap"><textarea name="default_text" type="text" class="inputBox textarea"  onChange='documentDirty=true;'><?php echo htmlspecialchars($content['default_text']);?></textarea><img src="<?php echo $_style["icons_tooltip"]?>" title="<?php echo $_lang['tmplvars_binding_msg']; ?>" class="tooltip" /></td>
   </tr>
   <tr>
     <td align="left"><?php echo $_lang['tmplvars_widget']; ?>:&nbsp;&nbsp;</td>
-    <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span>
-        <select name="display" size="1" class="inputBox" style="width:300px;" onChange='documentDirty=true;showParameters(this);'>
+    <td align="left">
+        <select name="display" size="1" onChange='documentDirty=true;showParameters(this);'>
 	            <option value="" <?php echo ($content['display']=='')? "selected='selected'":""; ?>>&nbsp;</option>
 			<optgroup label="Widgets">
 	            <option value="datagrid" <?php echo ($content['display']=='datagrid')? "selected='selected'":""; ?>>Data Grid</option>
@@ -353,7 +353,7 @@ function decode(s){
   </tr>
   <tr>
     <td align="left"><?php echo $_lang['tmplvars_rank']; ?>:&nbsp;&nbsp;</td>
-    <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="rank" type="text" maxlength="4" value="<?php echo (isset($content['rank'])) ? $content['rank'] : 0;?>" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+    <td align="left"><input name="rank" type="text" maxlength="4" value="<?php echo (isset($content['rank'])) ? $content['rank'] : 0;?>" class="inputBox" onChange='documentDirty=true;'></td>
   </tr>
   <tr>
     <td align="left" colspan="2"><input name="locked" value="on" type="checkbox" <?php echo $content['locked']==1 ? "checked='checked'" : "" ;?> class="inputBox" /> <?php echo $_lang['lock_tmplvars']; ?> <span class="comment"><?php echo $_lang['lock_tmplvars_msg']; ?></span></td>
@@ -460,10 +460,10 @@ function decode(s){
 <?php }?>
 
 <div class="sectionHeader"><?php echo $_lang['category_heading']; ?></div><div class="sectionBody">
-        <table width="90%" border="0" cellspacing="0" cellpadding="0">
+        <table width="90%" border="0">
           <tr>
             <td align="left"><?php echo $_lang['existing_category']; ?>:&nbsp;&nbsp;</td>
-            <td align="left"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><select name="categoryid" style="width:300px;" onChange='documentDirty=true;'>
+            <td align="left"><select name="categoryid" onChange='documentDirty=true;'>
 	            	<option>&nbsp;</option>
 	            <?php
 	                include_once "categories.inc.php";
@@ -476,8 +476,8 @@ function decode(s){
             </td>
           </tr>
           <tr>
-            <td align="left" valign="top" style="padding-top:5px;"><?php echo $_lang['new_category']; ?>:</td>
-            <td align="left" valign="top" style="padding-top:5px;"><span style="font-family:'Courier New', Courier, mono">&nbsp;&nbsp;</span><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" style="width:300px;" onChange='documentDirty=true;'></td>
+            <td align="left"><?php echo $_lang['new_category']; ?>:</td>
+            <td align="left"><input name="newcategory" type="text" maxlength="45" value="" class="inputBox" onChange='documentDirty=true;'></td>
           </tr>
         </table>
             </div>

--- a/manager/actions/sysinfo.static.php
+++ b/manager/actions/sysinfo.static.php
@@ -127,7 +127,7 @@ if(!$modx->hasPermission('logs')) {
 <!-- recent documents -->
 <div class="sectionHeader"><?php echo $_lang["activity_title"]; ?></div><div class="sectionBody" id="lyr1">
 		<?php echo $_lang["sysinfo_activity_message"]; ?><p>
-		<table border="0" cellpadding="1" cellspacing="1" width="100%" bgcolor="#ccc">
+		<table border="0" cellpadding="1" cellspacing="1" width="100%" class="table">
 			<thead>
 			<tr>
 				<td><b><?php echo $_lang["id"]; ?></b></td>
@@ -154,8 +154,8 @@ if(!$modx->hasPermission('logs')) {
 					$r = $modx->db->getRow($rs2);
 					$user = $r['username'];
 				}
-				$bgcolor = ($i % 2) ? '#EEEEEE' : '#FFFFFF';
-				echo "<tr bgcolor='$bgcolor'><td>".$content['id']."</td><td><a href='index.php?a=3&id=".$content['id']."'>".$content['pagetitle']."</a></td><td>".$user."</td><td>".$modx->toDateFormat($content['editedon']+$server_offset_time)."</td></tr>";
+				$bgcolor = ($i % 2) ? 'odd' : 'even';
+				echo "<tr class='".$bgcolor."'><td>".$content['id']."</td><td><a href='index.php?a=3&id=".$content['id']."'>".$content['pagetitle']."</a></td><td>".$user."</td><td>".$modx->toDateFormat($content['editedon']+$server_offset_time)."</td></tr>";
 			}
 		}
 		?>
@@ -174,7 +174,7 @@ $db_info->output(53, false);
 
 		<?php
 		$html = $_lang["onlineusers_message"].'<b>'.strftime('%H:%M:%S', time()+$server_offset_time).'</b>):<br /><br />
-                <table border="0" cellpadding="1" cellspacing="1" width="100%" bgcolor="#ccc">
+                <table border="0" cellpadding="1" cellspacing="1" width="100%" class="table">
                   <thead>
                     <tr>
                       <td><b>'.$_lang["onlineusers_user"].'</b></td>
@@ -202,7 +202,8 @@ $db_info->output(53, false);
 				$activeusers = $modx->db->getRow($rs);
 				$currentaction = getAction($activeusers['action'], $activeusers['id']);
 				$webicon = ($activeusers['internalKey']<0)? "<img align='absmiddle' src='media/style/{$manager_theme}/images/tree/globe.gif' alt='Web user'>":"";
-				$html .= "<tr bgcolor='#FFFFFF'><td><b>".$activeusers['username']."</b></td><td>$webicon&nbsp;".abs($activeusers['internalKey'])."</td><td>".$activeusers['ip']."</td><td>".strftime('%H:%M:%S', $activeusers['lasthit']+$server_offset_time)."</td><td>$currentaction</td><td align='right'>".$activeusers['action']."</td></tr>";
+				$bgcolor = ($i % 2) ? 'odd' : 'even';
+				$html .= "<tr class='".$bgcolor."'><td><b>".$activeusers['username']."</b></td><td>$webicon&nbsp;".abs($activeusers['internalKey'])."</td><td>".$activeusers['ip']."</td><td>".strftime('%H:%M:%S', $activeusers['lasthit']+$server_offset_time)."</td><td>$currentaction</td><td align='right'>".$activeusers['action']."</td></tr>";
 			}
 		}
 		echo $html;

--- a/manager/includes/header.inc.php
+++ b/manager/includes/header.inc.php
@@ -114,7 +114,7 @@ $onManagerMainFrameHeaderHTMLBlock = is_array($evtOut) ? '<div id="onManagerMain
 		}
 
 		function saveWait(fName) {
-			document.getElementById("savingMessage").innerHTML = "<?php echo $_lang['saving']; ?>";
+			$('#savingMessage').html("<?php echo $_lang['saving']; ?>");
 			for(i = 0; i < document.forms[fName].elements.length; i++) {
 				document.forms[fName].elements[i].disabled='disabled';
 			}

--- a/manager/includes/tmplvars.inc.php
+++ b/manager/includes/tmplvars.inc.php
@@ -17,16 +17,16 @@
 			case "rawtext"; // non-htmlentity converted text boxes
 			case "email": // handles email input fields
 			case "number": // handles the input of numbers
-				$field_html .=  '<input type="text" id="tv'.$field_id.'" name="tv'.$field_id.'" value="'.htmlspecialchars($field_value).'" '.$field_style.' tvtype="'.$field_type.'" onchange="documentDirty=true;" style="width:100%" />';
+				$field_html .=  '<input type="text" id="tv'.$field_id.'" name="tv'.$field_id.'" value="'.htmlspecialchars($field_value).'" '.$field_style.' tvtype="'.$field_type.'" onchange="documentDirty=true;" />';
 				break;
 			case "textareamini": // handler for textarea mini boxes
-				$field_html .=  '<textarea id="tv'.$field_id.'" name="tv'.$field_id.'" cols="40" rows="5" onchange="documentDirty=true;" style="width:100%">' . htmlspecialchars($field_value) .'</textarea>';
+				$field_html .=  '<textarea id="tv'.$field_id.'" name="tv'.$field_id.'" cols="40" rows="5" onchange="documentDirty=true;" style="width:99%">' . htmlspecialchars($field_value) .'</textarea>';
 				break;
 			case "textarea": // handler for textarea boxes
 			case "rawtextarea": // non-htmlentity convertex textarea boxes
 			case "htmlarea": // handler for textarea boxes (deprecated)
 			case "richtext": // handler for textarea boxes
-				$field_html .=  '<textarea id="tv'.$field_id.'" name="tv'.$field_id.'" cols="40" rows="15" onchange="documentDirty=true;" style="width:100%;">' . htmlspecialchars($field_value) .'</textarea>';
+				$field_html .=  '<textarea id="tv'.$field_id.'" name="tv'.$field_id.'" cols="40" rows="15" onchange="documentDirty=true;" style="width:99%;">' . htmlspecialchars($field_value) .'</textarea>';
 				break;
 			case "date":
 				$field_id = str_replace(array('-', '.'),'_', urldecode($field_id));	

--- a/manager/media/style/ClipperModern/style.css
+++ b/manager/media/style/ClipperModern/style.css
@@ -165,7 +165,7 @@ hr {
 	float: left;
 	padding: 0 20px 20px;
 }
-	.rtl .right {
+	.rtl .right, .pull-right{
 		float: right;
 	}
 #loadingmask {
@@ -339,7 +339,12 @@ select {
 	-webkit-border-radius: 2px;
 	-moz-border-radius: 2px;
 	border-radius: 2px;
-	
+	margin: 1px 0;
+}
+
+.sectionBody select, #settingsPane select{
+	line-height: 37px;
+	height: 37px;
 }
 
 input.checkbox,
@@ -1348,18 +1353,17 @@ ul.actionButtons {
 #Button1 select,
 .actionButtons select {
 	position: relative;
-	top: -6px;
-	padding: 5px 2px 4px;
-	background: #DDD url(images/misc/button-gradient.jpg) repeat-x top left;
-    border: 1px solid #B5B5B5 !important;
+	top: -4px;
+	border: 1px solid #B5B5B5 !important;
 	-webkit-border-radius: 0px;
 	-moz-border-radius: 0px;
 	border-radius: 0px;
-	
+	margin: 0;
+	padding: 5px 8px;
+	line-height: 26px;
+	height:26px;
 }
-#which_editor {
-	padding: 2px;
-}
+
 #ta_parent {
 	display: block;
 	margin: 0 0 10px;
@@ -1483,10 +1487,7 @@ form#mutate textarea {
 .inputBox[name="caption"] {
 	width: 400px !important;
 }
-.inputBox[name="newcategory"] {
-	width: 386px !important;
-	margin-top: -4px;
-}
+
 .inputBox.textarea {
 	width: 300px;
 }
@@ -1494,18 +1495,6 @@ form#mutate textarea {
 .searchtext[name="search"] {
 	padding: 4px 8px;
 }
-
-select[name="categoryid"] {
-	width: 404px !important;
-}
-select[name="type"] {
-	width: 318px !important;
-}
-select[name="display"] {
-	width: 318px !important;
-	margin-left: -3px
-}
-
 form#mutate input.inputBox,
 form#mutate textarea,
 div.tmplvars input {
@@ -1618,7 +1607,6 @@ input.DatePicker, #mutate input.DatePicker, #userPane input.DatePicker, #webUser
 	opacity: 0.98;		
 }
 input:focus.DatePicker, #mutate input:focus.DatePicker, #userPane input:focus.DatePicker, #webUserPane input:focus.DatePicker, input#datefrom:focus.DatePicker, input#dateto:focus.DatePicker {
-	background: #fffce9 url(images/icons/datefocus.gif) no-repeat top left;
 	cursor:text;
 }
 .dp_container {
@@ -1716,3 +1704,62 @@ input:focus.DatePicker, #mutate input:focus.DatePicker, #userPane input:focus.Da
 
 .sectionBody .phptextarea, .phptextarea {font-family: 'Courier New','Courier', monospace;}
 
+
+
+/*Tags*/
+.tv-tag{
+	position: relative;	
+}
+.tv-tag:before{
+	position: absolute;
+	content: "[* ";
+	top:0px;
+	left:-10px;
+}
+.tv-tag:after{
+	position: absolute;
+	content: " *]";
+	top:0px;
+	right:-10px;
+}
+
+
+.chunk-tag{
+	position: relative;	
+}
+.chunk-tag:before{
+	position: absolute;
+	content: "{{ ";
+	top:0px;
+	left:-10px;
+}
+.chunk-tag:after{
+	position: absolute;
+	content: " }}";
+	top:0px;
+	right:-10px;
+}
+
+.snippet-tag{
+	position: relative;	
+}
+.snippet-tag:before{
+	position: absolute;
+	content: "[[ ";
+	top:0px;
+	left:-10px;
+}
+.snippet-tag:after{
+	position: absolute;
+	content: " ]]";
+	top:0px;
+	right:-10px;
+}
+
+
+
+
+/*Fix jquery ui datepicker*/
+.ui-datepicker-title select{
+	padding: 0;
+}

--- a/manager/media/style/common/style.css
+++ b/manager/media/style/common/style.css
@@ -144,7 +144,7 @@ thead tr {
     }
 
 tbody tr {
-    background: #fff;
+    background: transparent;
     }
 
 tr.odd {


### PR DESCRIPTION
also removed some not needed html
a css(using :before and :after) way of showing the tags for the
elements section
tested in safari, chrome, FF, IE8 and 9
