### PR TITLE
usertype in LogEvent

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1915,19 +1915,30 @@ class DocumentParser extends Core {
         } else {
             $source = substr($source, 0, 50);
         }
+		
         $LoginUserID = $this->getLoginUserID();
         if ($LoginUserID == '') $LoginUserID = 0;
+		
+		$usertype = $this->isFrontend() ? 1 : 0;
+		
         $evtid= intval($evtid);
         $type = intval($type);
         if ($type < 1) {
             $type= 1;
-        }
-        elseif ($type > 3) {
+        } elseif ($type > 3) {
             $type= 3; // Types: 1 = information, 2 = warning, 3 = error
         }
-        $sql= "INSERT INTO " . $this->getFullTableName("event_log") . " (eventid,type,createdon,source,description,user) " .
-                "VALUES($evtid,$type," . time() . ",'$source','$msg','" . $LoginUserID . "')";
-        $ds= @$this->db->query($sql);
+		
+		$ds = $this->db->insert(array(
+			'eventid' => $evtid,
+			'type' =>$type,
+			'createdon' => time(),
+			'source' => $source,
+			'description' => $msg, 
+			'user' => $LoginUserID,
+			'usertype' => $usertype
+		), $this->getFullTableName("event_log"));
+		
         if (!$ds) {
             echo "Error while inserting event log into database.";
             exit();


### PR DESCRIPTION
Method getLoginUserID() can give a web user or manager. But if the user is a web user, the reports will show login manager. Look at [actions/eventlog.dynamic.php](https://github.com/ClipperCMS/ClipperCMS/blob/develop/manager/actions/eventlog.dynamic.php#L92-L97):

``` php
$sql = "SELECT el.id, el.type, el.createdon, el.source, el.eventid,IFNULL(wu.username,mu.username) as 'username' " .
"FROM ".$tbl_event_log." el ".
"LEFT JOIN ".$tbl_manager_users." mu ON mu.id=el.user AND el.usertype=0 ".
"LEFT JOIN ".$tbl_web_users." wu ON wu.id=el.user AND el.usertype=1 ".
 ($sqlQuery ? " WHERE ".(is_numeric($sqlQuery)?"(eventid='$sqlQuery') OR ":'')."(source LIKE '%$sqlQuery%') OR (description LIKE '%$sqlQuery%')":"")." ".
"ORDER BY createdon DESC";
```
