### PR TITLE
Replace deprecated /e modifier with callback in RewriteUrls()

### DIFF
--- a/install/assets/snippets/list.tpl
+++ b/install/assets/snippets/list.tpl
@@ -186,7 +186,7 @@ $language_files = array(
 foreach ($language_files as $filevalue) {
     if (file_exists($filevalue)) {
         require($filevalue);
-        if (!$modx->convertLanguageArray('_lang', $language_files['base_language'], '_lang')) {
+        if (!$modx->convertLanguageArray($_lang, $language_files['base_language'], '_lang')) {
             $modx->logEvent(1, 3, "Language file cannot be completely converted to {$modx->config['modx_charset']}. Please check: $filevalue");
         }
     } else {

--- a/install/assets/snippets/list.tpl
+++ b/install/assets/snippets/list.tpl
@@ -184,7 +184,7 @@ $language_files = array(
     'language' => $ditto_base."lang/$language.inc.php"
 );
 foreach ($language_files as $filevalue) {
-    if (file_exists(($filevalue)) {
+    if (file_exists($filevalue)) {
         require($filevalue);
         if (!$modx->convertLanguageArray('_lang', $language_files['base_language'], '_lang')) {
             $modx->logEvent(1, 3, "Language file cannot be completely converted to {$modx->config['modx_charset']}. Please check: $filevalue");

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1422,16 +1422,23 @@ class DocumentParser extends Core {
         return ($dir != '' ? "$dir/" : '') . $pre . $alias . $suff;
     }
 
-    /** 
+    /**
      * Convert URL tags [~...~] to URLs
      *
      * Simplified code compared to previous version. Uses makeURL(). Can cope with extraneous spaces.
+     * Replace uses callback to avoid deprecated /e modifier
      *
      * @param string $documentSource
      * @return string
      */
+    private function rewriteReplace($matches) {
+        return substr($this->makeURL($matches[1]), strlen($this->config['base_url']));
+    }
+
     function rewriteUrls($documentSource) {
-  	    return preg_replace('!\[\~\s*([0-9]+)\s*\~\]!ise', "substr(\$this->makeURL('\\1'), strlen(\$this->config['base_url']))", $documentSource);
+  	    return preg_replace_callback('!\[\~\s*([0-9]+)\s*\~\]!is',
+        array($this, 'rewriteReplace'),
+        $documentSource);
     }
 
     /**


### PR DESCRIPTION
As previously included into 1.2.x/1.2.7. 
